### PR TITLE
Add Interface Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Here's an example.
   {
     "name": "Notify",
     "address": "43:02:dc:b2:ab:23",
+    "interface": "en0",
     "url": "https://maker.ifttt.com/trigger/Notify/with/key/5212ssx2k23k2k",
     "method": "POST",
     "json": true,
@@ -58,6 +59,7 @@ Buttons take up to 7 options.
 
 * `name` - Optionally give the button action a name.
 * `address` - The MAC address of the button.
+* `interface` - Optionally listen for the button on a specific network interface. (`enX` on OS X and `ethX` on Linux)
 * `url` - The URL that will be requested.
 * `method` - The HTTP method of the request.
 * `headers` - Optional headers to use in the request.

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -2,6 +2,7 @@
   {
     "name": "Start Party Time",
     "address": "d8:02:dc:98:63:49",
+    "interface": "en0",
     "url": "http://192.168.1.55:8123/api/services/scene/turn_on",
     "method": "POST",
     "headers": {"authorization": "your_password"},

--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -5,7 +5,7 @@ var request = require('request')
 function DasherButton(button) {
   var options = {headers: button.headers, body: button.body, json: button.json}
 
-  this.dashButton = dashButton(button.address)
+  this.dashButton = dashButton(button.address, button.interface)
 
   this.dashButton.on("detected", function() {
     console.log(button.name + " pressed.")

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/maddox/dasher/issues"
   },
   "dependencies": {
-    "node-dash-button": "^0.1.1",
+    "node-dash-button": "^0.3.0",
     "request": "^2.60.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dasher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple way to bridge your Amazon Dash buttons to HTTP services.",
   "scripts": {
     "start": "node app.js"


### PR DESCRIPTION
This bumps `node-dash-button` version and enables the option to specify which network interface is used to listen for the button.

Add this to your button definition in `config.json`.

```json
"interface": "en1"
```