### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node
+
+RUN apt-get update && \
+    apt-get install -y \
+    libpcap-dev
+
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app
+
+VOLUME /usr/src/app/config
+
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "2"
+services:
+  dasher:
+    build: .
+    network_mode: host
+    privileged: true
+    restart: always
+    volumes:
+      - ~/configs/dasher:/usr/src/app/config


### PR DESCRIPTION
👋 @maddox 

So I added docker support for you.  I included an example `docker-compose.yml` file too.  If you end up pushing an image up to docker hub, you'll want to change the `build: .` line to `image: maddox/dasher`.

One caveat: since the docker image runs as root, I skipped your setup script and instead ran the button finder directly:

``` bash
docker run -it --rm --privileged --net=host tekkub/dasher \
  node node_modules/node-dash-button/bin/findbutton
```