### PR TITLE
Add check for nil response

### DIFF
--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -35,11 +35,11 @@ function doRequest(requestUrl, method, options, callback) {
       console.log("there was an error");
       console.log(error);
     }
-    if (response.statusCode === 401) {
+    if (response && response.statusCode === 401) {
       console.log("Not authenticated");
       console.log(error);
     }
-    if (response.statusCode !== 200) {
+    if (response && response.statusCode !== 200) {
       console.log("Not a 200");
       console.log(error);
     }


### PR DESCRIPTION
The app was erroring on missing statusCode when no response
was received. This allows the app not to crash if the url
doesn't respond.

Also removing the example config.