### PR TITLE
Accept all 200s status codes without printing

### DIFF
--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -39,8 +39,8 @@ function doRequest(requestUrl, method, options, callback) {
       console.log("Not authenticated");
       console.log(error);
     }
-    if (response && response.statusCode !== 200) {
-      console.log("Not a 200");
+    if (response && response.statusCode < 200 || response.statusCode > 299) {
+      console.log("Unsuccessful status code");
       console.log(error);
     }
 


### PR DESCRIPTION
@maddox Thanks for all the work on this.  The API I'm hitting responds 204 (No Content) on success.  I'm submitting a minor change to accept the entire range of 200s as successful and only print outside that range.