### PR TITLE
Added protocol support for newer dash buttons. Added documentation for Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Buttons take up to 7 options.
 * `name` - Optionally give the button action a name.
 * `address` - The MAC address of the button.
 * `interface` - Optionally listen for the button on a specific network interface. (`enX` on OS X and `ethX` on Linux)
-* `timeout` - Optionally set the time required between button press detections (if multiple pressese are detected) in milliseconds
-* `protocol` - Optionally set the protocol for your Dash button. Options are udp and arp. Default/null listens to both protocols. The "newer" JK29LP button from ~Q2 2016+ tends to use udp. 
+* `timeout` - Optionally set the time required between button press detections (if multiple pressese are detected) in milliseconds. Default is 5000.
+* `protocol` - Optionally set the protocol for your Dash button. Options are udp, arp, and all. Default listens to arp. The "newer" JK29LP button from ~Q2 2016+ tends to use udp. 
 * `url` - The URL that will be requested.
 * `method` - The HTTP method of the request.
 * `headers` - Optional headers to use in the request.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ MAC address. Run this:
 
     script/find_button
 
-Click your button the script will listen for your device. Look for the MAC address reported by watching for your button. Dash buttons should appear as manufactured by 'Amazon Technologies Inc.'. Once you have
+Click your Dash button and the script will listen for your device. Dash buttons should appear as manufactured by 'Amazon Technologies Inc.'. Once you have
 its MAC address you will be able to configure it in Dasher by modifying `config.json` in `/config` after installing Dasher.
 
 ### Dasher app

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Replace nodejs-legacy with node and manually update to the latest version of nod
     wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
     sudo dpkg -i node_latest_armhf.deb
 
-**Quick Start** Updated (11/20/16)
+**Quick Start** Works as of (1/27/17)
 
 Starting from a fresh Raspberry Pi Build? 
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Here's an example.
     "url": "http://192.168.1.55:8181/playlists/cooking/play",
     "method": "PUT"
   },
+  {
+    "name": "Debug Dash Button",
+    "address": "41:02:dc:b2:az:23",
+	"debug": true
+  }  
 ]}
 ```
 
@@ -62,11 +67,13 @@ Buttons take up to 7 options.
 * `address` - The MAC address of the button.
 * `interface` - Optionally listen for the button on a specific network interface. (`enX` on OS X and `ethX` on Linux)
 * `timeout` - Optionally set the time required between button press detections (if multiple pressese are detected) in milliseconds
+* `protocol` - Optionally set the time protocol for your Dash button. Options are udp and arp. Default listens to both protocols. The "newer ~(2016)" JK29LP tends to use udp. 
 * `url` - The URL that will be requested.
 * `method` - The HTTP method of the request.
 * `headers` - Optional headers to use in the request.
 * `json` - Optionally declare the content body as being JSON in the request.
 * `body` - Optionally provide a content-body that will be sent with the request.
+* `debug` - Used for testing button presses and will -not- perform a request.
 
 Setting and using these values should be enough to cover almost every kind of
 HTTP request you need to make.
@@ -82,6 +89,7 @@ Here are few protips about Dash buttons that will help you plan how to use them.
 * Dash buttons are discrete buttons. There is no on or off. They just do a
 single command.
 * Dash buttons can not be used for another ~10 seconds after they've been pressed.
+* If your Dash button is using udp, specify it in the button config.
 
 Dash buttons should be used to trigger specific things. I.E. a scene in
 your home automation, as a way to turn everything off in your house, or
@@ -109,7 +117,7 @@ MAC address. Run this:
 
 You will be prompted for your password, and then it will listen for your Dash
 button. Click your button and look for the MAC address reported. Once you have
-its MAC address you will be able to configure it in Dasher.
+its MAC address you will be able to configure it in Dasher by modifying `config.json` in `/config`. 
 
 ### Dasher app
 
@@ -127,7 +135,7 @@ Set up Dasher.
     npm install
 
 Then create a `config.json` in `/config` to set up your Dash buttons. Use the
-example to help you.
+example to help you. If you just want to test out the button press, use the debug button example.
 
 
 ## Running It

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Here's an example.
     "address": "43:02:dc:b2:ab:23",
     "interface": "en0",
     "timeout": "60000",
+    "protocol": "udp",
     "url": "https://maker.ifttt.com/trigger/Notify/with/key/5212ssx2k23k2k",
     "method": "POST",
     "json": true,
@@ -56,7 +57,7 @@ Here's an example.
   {
     "name": "Debug Dash Button",
     "address": "41:02:dc:b2:az:23",
-	"debug": true
+    "debug": true
   }  
 ]}
 ```
@@ -67,7 +68,7 @@ Buttons take up to 7 options.
 * `address` - The MAC address of the button.
 * `interface` - Optionally listen for the button on a specific network interface. (`enX` on OS X and `ethX` on Linux)
 * `timeout` - Optionally set the time required between button press detections (if multiple pressese are detected) in milliseconds
-* `protocol` - Optionally set the time protocol for your Dash button. Options are udp and arp. Default listens to both protocols. The "newer ~(2016)" JK29LP tends to use udp. 
+* `protocol` - Optionally set the protocol for your Dash button. Options are udp and arp. Default/null listens to both protocols. The "newer" JK29LP button from ~Q2 2016+ tends to use udp. 
 * `url` - The URL that will be requested.
 * `method` - The HTTP method of the request.
 * `headers` - Optional headers to use in the request.
@@ -115,9 +116,8 @@ MAC address. Run this:
 
     script/find_button
 
-You will be prompted for your password, and then it will listen for your Dash
-button. Click your button and look for the MAC address reported. Once you have
-its MAC address you will be able to configure it in Dasher by modifying `config.json` in `/config`. 
+Click your button the script will listen for your device. Look for the MAC address reported by watching for your button. Dash buttons should appear as manufactured by 'Amazon Technologies Inc.'. Once you have
+its MAC address you will be able to configure it in Dasher by modifying `config.json` in `/config` after installing Dasher.
 
 ### Dasher app
 

--- a/README.md
+++ b/README.md
@@ -121,21 +121,21 @@ its MAC address you will be able to configure it in Dasher by modifying `config.
 
 ### Dasher app
 
-Simply clone and install the dependencies.
+Simply **install the dependencies** and **clone the repository**.
 
 **note:** You might need to install `libpcap-dev` or `npm` on Linux first.
 
     sudo apt-get install libpcap-dev
     sudo apt-get install npm
 
-**note** Raspberry Pi users may need to update node which will automatically remove nodejs-legacy. One you are on node mainline, force the update to the latest version of node for arm. This may not be needed if you are running a first generation pi. If you are on a Pi and run into problems with npm install, try this. Credit @legotheboss
+**note** Raspberry Pi users may need to update node arm which will automatically remove nodejs-legacy. Credit @legotheboss
 
     sudo apt-get install node
 
     wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
     sudo dpkg -i node_latest_armhf.deb
 
-Set up Dasher.
+**Clone and Set up Dasher**
 
     git clone https://github.com/maddox/dasher.git
     cd dasher
@@ -158,13 +158,17 @@ After setting it up with `script/bootstrap` just run `script/install` to load Da
 You can uninstall it with `script/uninstall` and restart it with `script/restart`.
 
 ### Raspberry Pi
-Having problems running npm install?  Replace nodejs-legacy with node and manually update to the latest version of node arm.
+**Having problems running npm install?**
+
+Raspberry Pi users may need to update node arm which will automatically remove nodejs-legacy. One you are on node mainline, force the update to the latest version of node for arm. This may not be needed if you are running a first generation pi. If you are on a Pi and run into problems with npm install, try this. Credit @legotheboss
+
+Replace nodejs-legacy with node and manually update to the latest version of node arm.
 
     sudo apt-get install node
     wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
     sudo dpkg -i node_latest_armhf.deb
 
-Quick Start Updated (11/20/16)
+**Quick Start** Updated (11/20/16)
 
 Starting from a fresh Raspberry Pi Build? 
 
@@ -175,13 +179,15 @@ Starting from a fresh Raspberry Pi Build?
     wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
     sudo dpkg -i node_latest_armhf.deb
 
-    git clone https://github.com/mmaddox/dasher.git
+    git clone https://github.com/maddox/dasher.git
     cd dasher
     sudo npm install
 
     sudo ./script/findbutton
     update /config/config.json
     sudo npm run start
+
+**Auto Starting**
 
 Advanced information on autostarting Dasher on your Raspberry Pi can be found [here](https://github.com/maddox/dasher/wiki/Running-Dasher-on-a-Raspberry-Pi-at-startup).     
 

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ Having problems running npm install?  Replace nodejs-legacy with node and manual
     wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
     sudo dpkg -i node_latest_armhf.deb
 
-Quick Start
-Starting from a fresh Raspberry Pi Build? Updated (11/20/16)
+Quick Start Updated (11/20/16)
+
+Starting from a fresh Raspberry Pi Build? 
 
     sudo apt-get install libpcap-dev
     sudo apt-get install npm
@@ -174,7 +175,7 @@ Starting from a fresh Raspberry Pi Build? Updated (11/20/16)
     wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
     sudo dpkg -i node_latest_armhf.deb
 
-    git clone https://github.com/maddows/dasher.git
+    git clone https://github.com/mmaddox/dasher.git
     cd dasher
     sudo npm install
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,15 @@ Simply clone and install the dependencies.
 
 **note:** You might need to install `libpcap-dev` or `npm` on Linux first.
 
-    $ sudo apt-get install libpcap-dev
-    $ sudo apt-get install npm
+    sudo apt-get install libpcap-dev
+    sudo apt-get install npm
+
+**note** Raspberry Pi users may need to update node which will automatically remove nodejs-legacy. One you are on node mainline, force the update to the latest version of node for arm. This may not be needed if you are running a first generation pi. If you are on a Pi and run into problems with npm install, try this. Credit @legotheboss
+
+    sudo apt-get install node
+
+    wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
+    sudo dpkg -i node_latest_armhf.deb
 
 Set up Dasher.
 
@@ -135,7 +142,7 @@ Set up Dasher.
     npm install
 
 Then create a `config.json` in `/config` to set up your Dash buttons. Use the
-example to help you. If you just want to test out the button press, use the debug button example.
+example to help you. If you just want to test the button press, use the debug button example with the MAC address you found running script/find_button. 
 
 
 ## Running It
@@ -151,6 +158,30 @@ After setting it up with `script/bootstrap` just run `script/install` to load Da
 You can uninstall it with `script/uninstall` and restart it with `script/restart`.
 
 ### Raspberry Pi
+Having problems running npm install?  Replace nodejs-legacy with node and manually update to the latest version of node arm.
+
+    sudo apt-get install node
+    wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
+    sudo dpkg -i node_latest_armhf.deb
+
+Quick Start
+Starting from a fresh Raspberry Pi Build? Updated (11/20/16)
+
+    sudo apt-get install libpcap-dev
+    sudo apt-get install npm
+
+    sudo apt-get install node
+    wget http://node-arm.herokuapp.com/node_latest_armhf.deb 
+    sudo dpkg -i node_latest_armhf.deb
+
+    git clone https://github.com/maddows/dasher.git
+    cd dasher
+    sudo npm install
+
+    sudo ./script/findbutton
+    update /config/config.json
+    sudo npm run start
+
 Advanced information on autostarting Dasher on your Raspberry Pi can be found [here](https://github.com/maddox/dasher/wiki/Running-Dasher-on-a-Raspberry-Pi-at-startup).     
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Here are few protips about Dash buttons that will help you plan how to use them.
 single command.
 * Dash buttons can not be used for another ~10 seconds after they've been pressed.
 * If your Dash button is using udp, specify it in the button config.
+* Listening over wifi is unreliable. I highly recommend using ethernet, especially  on Raspberry Pi
 
 Dash buttons should be used to trigger specific things. I.E. a scene in
 your home automation, as a way to turn everything off in your house, or
@@ -117,7 +118,7 @@ MAC address. Run this:
     script/find_button
 
 Click your Dash button and the script will listen for your device. Dash buttons should appear as manufactured by 'Amazon Technologies Inc.'. Once you have
-its MAC address you will be able to configure it in Dasher by modifying `config.json` in `/config` after installing Dasher.
+its MAC address you will be able to configure it in Dasher by modifying `config/config.json` after installing Dasher.
 
 ### Dasher app
 

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,9 +1,15 @@
 {"buttons":[
   {
+    "name": "Debug Dash Button",
+    "address": "d8:02:dc:98:63:49",
+	"debug": true
+  },
+  {
     "name": "Start Party Time",
     "address": "d8:02:dc:98:63:49",
     "interface": "en0",
     "timeout": "60000",
+    "protocol": "udp",	
     "url": "http://192.168.1.55:8123/api/services/scene/turn_on",
     "method": "POST",
     "headers": {"x-ha-access": "your_password"},
@@ -13,6 +19,7 @@
   {
     "name": "Start Cooking Playlist",
     "address": "66:a0:dc:98:d2:63",
+    "protocol": "arp",	
     "url": "http://192.168.1.55:8181/playlists/cooking/play",
     "method": "PUT"
   },

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -9,7 +9,7 @@
     "address": "d8:02:dc:98:63:49",
     "interface": "en0",
     "timeout": "60000",
-    "protocol": "udp",	
+    "protocol": "udp",
     "url": "http://192.168.1.55:8123/api/services/scene/turn_on",
     "method": "POST",
     "headers": {"x-ha-access": "your_password"},

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -2,7 +2,7 @@
   {
     "name": "Debug Dash Button",
     "address": "d8:02:dc:98:63:49",
-	"debug": true
+    "debug": true
   },
   {
     "name": "Start Party Time",

--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -4,12 +4,16 @@ var request = require('request')
 
 function DasherButton(button) {
   var options = {headers: button.headers, body: button.body, json: button.json}
-
-  this.dashButton = dashButton(button.address, button.interface, button.timeout)
+  var debug = button.debug || false;
+  this.dashButton = dashButton(button.address, button.interface, button.timeout, button.protocol)
 
   this.dashButton.on("detected", function() {
     console.log(button.name + " pressed.")
-    doRequest(button.url, button.method, options)
+	if (debug){
+	  console.log("Debug mode, skipping request.");
+	} else {
+      doRequest(button.url, button.method, options)
+    }
   })
 
   console.log(button.name + " added.")
@@ -35,15 +39,18 @@ function doRequest(requestUrl, method, options, callback) {
       console.log("there was an error");
       console.log(error);
     }
-    if (response && response.statusCode === 401) {
-      console.log("Not authenticated");
-      console.log(error);
-    }
-    if (response && response.statusCode < 200 || response.statusCode > 299) {
-      console.log("Unsuccessful status code");
-      console.log(error);
-    }
-
+	if (response) {
+      if (response.statusCode === 401) {
+        console.log("Not authenticated");
+        console.log(error);
+      }
+      if (response.statusCode < 200 || response.statusCode > 299) {
+        console.log("Unsuccessful status code");
+        console.log(error);
+	  }
+	} else {
+		console.log("Response undefined");
+	}
     if (callback) {
       callback(error, response, body)
     }

--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -6,11 +6,18 @@ function DasherButton(button) {
   var options = {headers: button.headers, body: button.body, json: button.json}
   var debug = button.debug || false;
   this.dashButton = dashButton(button.address, button.interface, button.timeout, button.protocol)
-
+  var buttonList = {};
   this.dashButton.on("detected", function() {
-    console.log(button.name + " pressed.")
+
+    if(!buttonList.hasOwnProperty(button.address)){
+        buttonList[button.address] = 1;
+    } else {
+        buttonList[button.address]++;
+    }
+    console.log(button.name + " pressed. Count: " +  buttonList[button.address]);    
     if (debug){
       console.log("Debug mode, skipping request.");
+      console.log(button);
     } else {
       doRequest(button.url, button.method, options)
     }

--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -2,6 +2,10 @@ var url = require('url')
 var dashButton = require('node-dash-button');
 var request = require('request')
 
+function doLog(message) {
+  console.log('[' + (new Date().toISOString()) + '] ' + message);
+}
+ 
 function DasherButton(button) {
   var options = {headers: button.headers, body: button.body, json: button.json}
   var debug = button.debug || false;
@@ -14,16 +18,16 @@ function DasherButton(button) {
     } else {
         buttonList[button.address]++;
     }
-    console.log(button.name + " pressed. Count: " +  buttonList[button.address]);    
+    doLog(button.name + " pressed. Count: " +  buttonList[button.address]);    
     if (debug){
-      console.log("Debug mode, skipping request.");
+      doLog("Debug mode, skipping request.");
       console.log(button);
     } else {
       doRequest(button.url, button.method, options)
     }
   })
 
-  console.log(button.name + " added.")
+  doLog(button.name + " added.")
 }
 
 function doRequest(requestUrl, method, options, callback) {
@@ -43,20 +47,20 @@ function doRequest(requestUrl, method, options, callback) {
 
   request(reqOpts, function onResponse(error, response, body) {
     if (error) {
-      console.log("there was an error");
-      console.log(error);
+      doLog("there was an error");
+      doLog(error);
     }
     if (response) {
       if (response.statusCode === 401) {
-        console.log("Not authenticated");
-        console.log(error);
+        doLog("Not authenticated");
+        doLog(error);
       }
       if (response.statusCode < 200 || response.statusCode > 299) {
-        console.log("Unsuccessful status code");
-        console.log(error);
+        doLog("Unsuccessful status code");
+        doLog(error);
       }
     } else {
-      console.log("Response undefined");
+      doLog("Response undefined");
     }
     if (callback) {
       callback(error, response, body)

--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -9,9 +9,9 @@ function DasherButton(button) {
 
   this.dashButton.on("detected", function() {
     console.log(button.name + " pressed.")
-	if (debug){
-	  console.log("Debug mode, skipping request.");
-	} else {
+    if (debug){
+      console.log("Debug mode, skipping request.");
+    } else {
       doRequest(button.url, button.method, options)
     }
   })
@@ -39,7 +39,7 @@ function doRequest(requestUrl, method, options, callback) {
       console.log("there was an error");
       console.log(error);
     }
-	if (response) {
+    if (response) {
       if (response.statusCode === 401) {
         console.log("Not authenticated");
         console.log(error);
@@ -47,10 +47,10 @@ function doRequest(requestUrl, method, options, callback) {
       if (response.statusCode < 200 || response.statusCode > 299) {
         console.log("Unsuccessful status code");
         console.log(error);
-	  }
-	} else {
-		console.log("Response undefined");
-	}
+      }
+    } else {
+      console.log("Response undefined");
+    }
     if (callback) {
       callback(error, response, body)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dasher",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A simple way to bridge your Amazon Dash buttons to HTTP services.",
   "scripts": {
     "start": "node app.js"


### PR DESCRIPTION
Hey all.

The biggest change here is adding support for manually specifying the listener protocol.  This is useful for working with the newer JK29LP button. I also added a few other minor helpers for getting noobs like myself  moving in the right direction such as a debug option that skips the request and some handling in case you have an undefined response due to misconfiguration.  I also updated the documentation to reflect some of the updates seen via the node-dash-button library.

I hope it helps!