### PR TITLE
Added date/time in logging

### DIFF
--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -2,17 +2,21 @@ var url = require('url')
 var dashButton = require('node-dash-button');
 var request = require('request')
 
+function doLog(message) {
+  console.log('[' + (new Date().toISOString()) + '] ' + message);
+}
+
 function DasherButton(button) {
   var options = {headers: button.headers, body: button.body, json: button.json}
 
   this.dashButton = dashButton(button.address, button.interface, button.timeout)
 
   this.dashButton.on("detected", function() {
-    console.log(button.name + " pressed.")
+    doLog(button.name + " pressed.")
     doRequest(button.url, button.method, options)
   })
 
-  console.log(button.name + " added.")
+  doLog(button.name + " added.")
 }
 
 function doRequest(requestUrl, method, options, callback) {
@@ -32,15 +36,15 @@ function doRequest(requestUrl, method, options, callback) {
 
   request(reqOpts, function onResponse(error, response, body) {
     if (error) {
-      console.log("there was an error");
+      doLog("there was an error");
       console.log(error);
     }
     if (response && response.statusCode === 401) {
-      console.log("Not authenticated");
+      doLog("Not authenticated");
       console.log(error);
     }
     if (response && response.statusCode < 200 || response.statusCode > 299) {
-      console.log("Unsuccessful status code");
+      doLog("Unsuccessful status code");
       console.log(error);
     }
 


### PR DESCRIPTION
I'm running dasher on my Raspberry Pi, and I often need to check logs in `/var/log/dasher.*`. Without a timestamps, they are not so useful.

I prefixed every `console.log` message with an ISO date/time. Hope it's ok.