### PR TITLE
Fixed reading statusCode from undefined response

### DIFF
--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -43,7 +43,7 @@ function doRequest(requestUrl, method, options, callback) {
       doLog("Not authenticated");
       console.log(error);
     }
-    if (response && response.statusCode < 200 || response.statusCode > 299) {
+    if (response && (response.statusCode < 200 || response.statusCode > 299)) {
       doLog("Unsuccessful status code");
       console.log(error);
     }


### PR DESCRIPTION
When the request fails, the `response` object can be undefined. When this happens, an uncatched error is throw in the line I fixed: because of the missing parenthesis, `response.statusCode` is evaluated when `response` is undefined. This crashes the daemon.