### PR TITLE
Fixed error logging after #35

### DIFF
--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -50,18 +50,14 @@ function doRequest(requestUrl, method, options, callback) {
   request(reqOpts, function onResponse(error, response, body) {
     if (error) {
       doLog("there was an error");
-    }
-    if (response) {
+      console.log(error);
+    } else {
       if (response.statusCode === 401) {
         doLog("Not authenticated");
-        doLog(error);
       }
       if (response.statusCode < 200 || response.statusCode > 299) {
         doLog("Unsuccessful status code");
-        doLog(error);
       }
-    } else {
-      doLog("Response undefined");
     }
     
     if (callback) {


### PR DESCRIPTION
Don't know why, but it looks like pull request #35 did change error logging code I commited some time ago, introducing a couple of issue I'll explain below. This fixes it.

1. The change in the conditional flow was wrong, in the sense that when a request error occurred, the app always logged a useless `response in undefined`, but that's obvious because only one of `error` and `response` can be defined at one time.

2. The logging of `error` object was been removed for some reason (see line 53), so when a request error occurred, the app logged `there was an error` without any further info.

Additionally, I removed the logging of the `error` object when `response` is defined, because as I said, if `reponse` is defined, then `error` is not.