### PR TITLE
Check if cmd is defined not just empty

### DIFF
--- a/lib/dasher.js
+++ b/lib/dasher.js
@@ -24,7 +24,7 @@ function DasherButton(button) {
     if (debug){
       doLog("Debug mode, skipping request.");
       console.log(button);
-    } else if (button.cmd != "") {
+    } else if (typeof button.cmd !== 'undefined' && button.cmd != "") {
       doCommand(button.cmd, button.name)
     } else {
       doRequest(button.url, button.method, options)


### PR DESCRIPTION
Just found that if I don't check if cmd is defined it tries to run the command and then crashes.

May be worth checking if the URL and method is defined before doing the doRequest command as well, just for belt and braces.